### PR TITLE
Add messageData attribute to Event

### DIFF
--- a/mpegdash/nodes.py
+++ b/mpegdash/nodes.py
@@ -284,18 +284,21 @@ class SegmentList(MultipleSegmentBase):
 class Event(XMLNode):
     def __init__(self):
         self.event_value = None                               # xs:string
+        self.message_data = None                              # xs:string
         self.presentation_time = None                         # xs:unsignedLong
         self.duration = None                                  # xs:unsignedLong
         self.id = None                                        # xs:unsignedInt
 
     def parse(self, xmlnode):
         self.event_value = parse_node_value(xmlnode, str)
+        self.message_data = parse_attr_value(xmlnode, 'messageData', str)
         self.presentation_time = parse_attr_value(xmlnode, 'presentationTime', int)
         self.duration = parse_attr_value(xmlnode, 'duration', int)
         self.id = parse_attr_value(xmlnode, 'id', int)
 
     def write(self, xmlnode):
         write_node_value(xmlnode, self.event_value)
+        write_attr_value(xmlnode, 'messageData', self.message_data)
         write_attr_value(xmlnode, 'presentationTime', self.presentation_time)
         write_attr_value(xmlnode, 'duration', self.duration)
         write_attr_value(xmlnode, 'id', self.id)

--- a/mpegdash/utils.py
+++ b/mpegdash/utils.py
@@ -30,7 +30,7 @@ def parse_child_nodes(xmlnode, tag_name, node_type):
 
 
 def parse_node_value(xmlnode, value_type):
-    node_val = xmlnode.firstChild.nodeValue
+    node_val = xmlnode.firstChild.nodeValue if xmlnode.firstChild else None
     if node_val:
         return value_type(node_val)
     return None

--- a/tests/mpd-samples/with_event_message_data.mpd
+++ b/tests/mpd-samples/with_event_message_data.mpd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="dynamic" id="123"
+  availabilityStartTime="1970-01-01T00:00:12Z"
+  publishTime="2019-03-11T16:45:56.926670Z"
+  minimumUpdatePeriod="PT2S"
+  maxSegmentDuration="PT2S"
+  minBufferTime="PT4S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:com:dashif:dash264">
+  <Period
+    id="1"
+    start="PT0S">
+    <EventStream
+      schemeIdUri="urn:scte:scte35:2014:bin"
+      timescale="10000000">
+      <Event
+        presentationTime="15523215530800000"
+        duration="260000000"
+        id="3344706862"
+        messageData="/DAlAAAAAAAAAP/wFAVchowMf+/+K9wjIP4AI7SgAAEBAQAASG43iQ==" />
+     <Event
+        presentationTime="15523215530800000"
+        duration="260000000"
+        id="3344706863">Some Random Event Text</Event>
+    </EventStream>
+    <AdaptationSet
+      id="1"
+      group="1"
+      contentType="audio"
+      lang="en"
+      segmentAlignment="true"
+      audioSamplingRate="48000"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2"
+      startWithSAP="1">
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2">
+      </AudioChannelConfiguration>
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main" />
+      <SegmentTemplate
+        timescale="48000"
+        initialization="$RepresentationID$.dash"
+        media="$RepresentationID$-$Time$.dash">
+        <SegmentTimeline>
+          <S t="74511434605440" d="92160" r="11" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="audio_128000_en=128000"
+        bandwidth="128000">
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <UTCTiming
+    schemeIdUri="urn:mpeg:dash:utc:http-iso:2014"
+    value="https://time.akamai.com/?iso" />
+</MPD>

--- a/tests/test_xmltompd.py
+++ b/tests/test_xmltompd.py
@@ -36,6 +36,13 @@ class XML2MPDTestCase(unittest.TestCase):
         mpd_url = 'http://yt-dash-mse-test.commondatastorage.googleapis.com/media/motion-20120802-manifest.mpd'
         self.assert_mpd(MPEGDASHParser.parse(mpd_url))
 
+    def test_xml2mpd_from_file_with_event_messagedata(self):
+        mpd = MPEGDASHParser.parse('./tests/mpd-samples/with_event_message_data.mpd')
+        self.assertTrue(mpd.periods[0].event_streams[0].events[0].message_data is not None)
+        self.assertTrue(mpd.periods[0].event_streams[0].events[0].event_value is None)
+        self.assertTrue(mpd.periods[0].event_streams[0].events[1].message_data is None)
+        self.assertEqual(mpd.periods[0].event_streams[0].events[1].event_value, "Some Random Event Text")
+
     def assert_mpd(self, mpd):
         self.assertTrue(mpd is not None)
         self.assertTrue(len(mpd.periods) > 0)


### PR DESCRIPTION
The 3rd edition of the DASH spec introduces the messageData attribute to Event, which seems to be preferred when the event data is represented as a string.

Existing mechanism still works (although I note this doesn't work properly when the Event carries XML as it would for SCTE35 - taking a look at that ...)