### PR TITLE
Add UTCTiming support

### DIFF
--- a/mpegdash/nodes.py
+++ b/mpegdash/nodes.py
@@ -690,6 +690,7 @@ class MPEGDASH(XMLNode):
         self.locations = None                                 # xs:anyURI*
         self.periods = None                                   # PeriodType+
         self.metrics = None                                   # MetricsType*
+        self.utc_timings = None                               # DescriptorType*
 
     def parse(self, xmlnode):
         self.xmlns = parse_attr_value(xmlnode, 'xmlns', str)
@@ -712,6 +713,7 @@ class MPEGDASH(XMLNode):
         self.locations = parse_child_nodes(xmlnode, 'Location', str)
         self.periods = parse_child_nodes(xmlnode, 'Period', Period)
         self.metrics = parse_child_nodes(xmlnode, 'Metrics', Metrics)
+        self.utc_timings = parse_child_nodes(xmlnode, 'UTCTiming', Descriptor)
 
     def write(self, xmlnode):
         write_attr_value(xmlnode, 'xmlns', self.xmlns)
@@ -734,3 +736,4 @@ class MPEGDASH(XMLNode):
         write_child_node(xmlnode, 'Location', self.locations)
         write_child_node(xmlnode, 'Period', self.periods)
         write_child_node(xmlnode, 'Metrics', self.metrics)
+        write_child_node(xmlnode, 'UTCTiming', self.utc_timings)

--- a/tests/mpd-samples/utc_timing.mpd
+++ b/tests/mpd-samples/utc_timing.mpd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static" id="1"
+  minBufferTime="PT4S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period
+    id="1"
+    start="PT0S"/>
+  <UTCTiming
+    schemeIdUri="urn:mpeg:dash:utc:http-iso:2014"
+    value="https://time.akamai.com/?iso" />
+</MPD>

--- a/tests/test_xmltompd.py
+++ b/tests/test_xmltompd.py
@@ -36,6 +36,11 @@ class XML2MPDTestCase(unittest.TestCase):
         mpd_url = 'http://yt-dash-mse-test.commondatastorage.googleapis.com/media/motion-20120802-manifest.mpd'
         self.assert_mpd(MPEGDASHParser.parse(mpd_url))
 
+    def test_xml2mpd_from_file_with_utc_timing(self):
+        mpd = MPEGDASHParser.parse('./tests/mpd-samples/utc_timing.mpd')
+        self.assertEqual(mpd.utc_timings[0].scheme_id_uri, 'urn:mpeg:dash:utc:http-iso:2014')
+        self.assertEqual(mpd.utc_timings[0].value, 'https://time.akamai.com/?iso')
+
     def assert_mpd(self, mpd):
         self.assertTrue(mpd is not None)
         self.assertTrue(len(mpd.periods) > 0)


### PR DESCRIPTION
The 3rd Edition of the DASH spec introduces a mechanism for signalling to clients sources of accurate timing information.

It's just a descriptor type (though obviously the meaning is determined by the schemeIdUri and value)