### PR TITLE
Fix parsing error due to title element

### DIFF
--- a/mpegdash/nodes.py
+++ b/mpegdash/nodes.py
@@ -65,6 +65,15 @@ class BaseURL(XMLNode):
         write_attr_value(xmlnode, 'availabilityTimeOffset', self.availability_time_offset)
         write_attr_value(xmlnode, 'availabilityTimeComplete', self.availability_time_complete)
 
+class Title(XMLNode):
+    def __init__(self):
+        self.title = None # xs:string*
+
+    def parse(self, xmlnode):
+        self.title = parse_node_value(xmlnode, str)
+
+    def write(self, xmlnode):
+        write_node_value(xmlnode, self.title)
 
 class ProgramInformation(XMLNode):
     def __init__(self):
@@ -79,7 +88,7 @@ class ProgramInformation(XMLNode):
         self.lang = parse_attr_value(xmlnode, 'lang', str)
         self.more_information_url = parse_attr_value(xmlnode, 'moreInformationURL', str)
 
-        self.titles = parse_child_nodes(xmlnode, 'Title', str)
+        self.titles = parse_child_nodes(xmlnode, 'Title', Title)
         self.sources = parse_child_nodes(xmlnode, 'Source', str)
         self.copyrights = parse_child_nodes(xmlnode, 'Copyright', str)
 

--- a/mpegdash/utils.py
+++ b/mpegdash/utils.py
@@ -20,7 +20,7 @@ def parse_child_nodes(xmlnode, tag_name, node_type):
     nodes = []
     for elem in elements:
         if node_type in (unicode, str):
-            node = xmlnode.firstChild.nodeValue
+            node = elem.firstChild.nodeValue
         else:
             node = node_type()
             node.parse(elem)


### PR DESCRIPTION
There is an error when you try to write a mpd file with a title.

from mpegdash.parser import MPEGDASHParser
mpd = MPEGDASHParser.parse("http://dash.akamaized.net/dash264/TestCasesIOP33/adapatationSetSwitching/5/manifest.mpd")

mpd.write(mpd, './test_mpd.mpd')

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "python-mpegdash/mpegdash/parser.py", line 35, in write
    write_child_node(xml_doc, 'MPD', mpd)
  File "python-mpegdash/mpegdash/utils.py", line 61, in write_child_node
    node.write(new_elem)
  File "python-mpegdash/mpegdash/nodes.py", line 737, in write
    write_child_node(xmlnode, 'ProgramInformation', self.program_informations)
  File "python-mpegdash/mpegdash/utils.py", line 57, in write_child_node
    n.write(new_elem)
  File "python-mpegdash/mpegdash/nodes.py", line 90, in write
    write_child_node(xmlnode, 'Title', self.titles)
  File "python-mpegdash/mpegdash/utils.py", line 57, in write_child_node
    n.write(new_elem)
